### PR TITLE
Allow TCP or UDP protocols for underlying sockets

### DIFF
--- a/core.c
+++ b/core.c
@@ -18,24 +18,32 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#pragma once
+#include "core.h"
+#include "tlssock.h"
 
-#define _GNU_SOURCE
-#include <stdbool.h>
-#include <dlfcn.h>
-
-#define __str(s) #s
-#define _str(s) __str(s)
-#define NEXT(name) ((typeof(name) *) dlsym(RTLD_NEXT, _str(name)))
+#include <sys/socket.h>
+#include <netinet/in.h>
 
 bool
-is_tls_domain(int domain);
+is_tls_domain(int domain)
+{
+    return domain == AF_INET || domain == AF_INET6;
+}
 
 bool
-is_tls_type(int type);
+is_tls_type(int type)
+{
+    return type == SOCK_STREAM || type == SOCK_DGRAM;
+}
 
 bool
-is_tls_protocol(int protocol);
+is_tls_protocol(int protocol)
+{
+    return protocol == PROT_TLS_CLIENT || protocol == PROT_TLS_SERVER;
+}
 
 bool
-is_tls_inner_protocol(int protocol);
+is_tls_inner_protocol(int protocol)
+{
+    return protocol == 0 || protocol == IPPROTO_TCP || protocol == IPPROTO_UDP;
+}

--- a/meson.build
+++ b/meson.build
@@ -39,7 +39,7 @@ threads = dependency('threads')
 
 install_headers('tlssock.h')
 libtlssock = shared_library('tlssock',
-  'core.h',
+  'core.c', 'core.h',
   'tls.c', 'tls.h',
   'idx.c', 'idx.h',
   'tlssock.c', 'tlssock.h',

--- a/tls.c
+++ b/tls.c
@@ -169,17 +169,17 @@ tls_new(int fd, bool client)
   if (getsockopt_int(fd, SOL_SOCKET, SO_PROTOCOL, &protocol) < 0)
     return NULL;
 
-  if (domain != AF_INET && domain != AF_INET6) {
+  if (!is_tls_domain(domain)) {
     errno = EINVAL; // FIXME
     return NULL;
   }
 
-  if (protocol != 0) {
+  if (!is_tls_type(type)) {
     errno = EINVAL; // FIXME
     return NULL;
   }
 
-  if (type != SOCK_STREAM && type != SOCK_DGRAM) {
+  if (!is_tls_inner_protocol(protocol)) {
     errno = EINVAL; // FIXME
     return NULL;
   }


### PR DESCRIPTION
If we set protocol 0, the libc will return the primary protocol, so 6 (tcp)
or 17 (udp).

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>