### PR TITLE
Use recv/send for non-stdio in the test tooling

### DIFF
--- a/bin/main.c
+++ b/bin/main.c
@@ -188,7 +188,10 @@ on_conn(options_t *opts, int con, int in, int out, const struct addrinfo *ai)
       if (!pfds[i].revents)
         continue;
 
-      ret = read(pfds[i].fd, buffer, sizeof(buffer));
+      if (pfds[i].fd <= 2)
+        ret = read(pfds[i].fd, buffer, sizeof(buffer));
+      else
+        ret = recv(pfds[i].fd, buffer, sizeof(buffer), 0);
       if (ret <= 0) {
         if (pfds[i].revents != POLLHUP &&
             (errno == EAGAIN || errno == EWOULDBLOCK))

--- a/bin/non.c
+++ b/bin/non.c
@@ -98,7 +98,10 @@ non_write(int fd, void *buf, size_t len)
   uint8_t *b = buf;
   ssize_t ret;
 
-  ret = write(fd, buf, len);
+  if (fd <= 2)
+    ret = write(fd, buf, len);
+  else
+    ret = send(fd, buf, len, 0);
   if (ret < 0) {
     if (errno != EAGAIN)
       return ret;


### PR DESCRIPTION
This should increase the test coverage to also cover send/recv.

AlternativeTo: #28
Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>